### PR TITLE
Fix temp file name

### DIFF
--- a/lib/wisepdf/render.rb
+++ b/lib/wisepdf/render.rb
@@ -71,7 +71,7 @@ module Wisepdf
           opts = arguments[hf].delete(:html)
           
           @hf_tempfiles = [] if ! defined?(@hf_tempfiles)
-          @hf_tempfiles.push( tf = Tempfile.new("wisepdf_#{hf}_pdf", '.html') )
+          @hf_tempfiles.push( tf = Tempfile.new(["wisepdf_#{hf}_pdf", '.html'], 'tmp') )
           opts[:layout] ||= arguments[:layout]
           
           tf.write render_to_string(:template => opts[:template], :layout => opts[:layout], :locals => opts[:locals])


### PR DESCRIPTION
Second parameter of Tempfile#new is location but not extension.

> Tempfile.new("name", '.html')
>    => #File:[...]/.html/name20120606-34108-1wmka7b 
> Tempfile.new(["name", '.html'], 'tmp')
>    => #File:[...]/tmp/name20120606-34108-sc8g1b.html 
