### PR TITLE
Bug save_to_file

### DIFF
--- a/lib/wisepdf/parser.rb
+++ b/lib/wisepdf/parser.rb
@@ -6,7 +6,7 @@ module Wisepdf
       :pdf, :layout, :template, :action, :partial,
       :object, :collection, :as, :spacer_template,
       :disposition, :locals, :status, :file, :text,
-      :xml, :json, :callback, :inline, :location
+      :xml, :json, :callback, :inline, :location, :save_to_file
     ]
        
     class << self


### PR DESCRIPTION
I've added save_to_file on the ESCAPED_OPTIONS parser.
This allow to save pdf as file.
