### PR TITLE
allow passing of a full file path to wisepdf_image_tag

### DIFF
--- a/lib/wisepdf/helper.rb
+++ b/lib/wisepdf/helper.rb
@@ -41,7 +41,11 @@ module Wisepdf
       end
 
       def wisepdf_image_tag(img, options={})
-        image_tag "file:///#{::Rails.application.assets.find_asset(img).pathname.to_s}", options
+        if File.exists? img
+          image_tag "file://#{img}", options
+        elsif asset = ::Rails.application.assets.find_asset(img)
+          image_tag "file:///#{asset.pathname.to_s}", options
+        end
       end
       
       def wisepdf_javascript_tag(*sources)


### PR DESCRIPTION
This enables compatibility with Paperclip::Attachment or other files outside the assets path
Also it won't error if the image is not found -- I wasn't sure if this behaviour was by design.
