### PR TITLE
Remove wkhtmltopdf-binary dependancy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source "http://rubygems.org"
 
 group :development, :test do
   gem 'sqlite3'
-
+  gem 'wkhtmltopdf-binary'
+  
   gem "shoulda", ">= 0"
   gem "bundler", ">= 1.0.0"
   gem "jeweler"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "http://rubygems.org"
 
 group :development, :test do
   gem 'sqlite3'
-  gem 'wkhtmltopdf-binary'
 
   gem "shoulda", ">= 0"
   gem "bundler", ">= 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.36)
+    wkhtmltopdf-binary (0.9.9.1)
 
 PLATFORMS
   ruby
@@ -107,3 +108,4 @@ DEPENDENCIES
   rails (>= 3.0.0)
   shoulda
   sqlite3
+  wkhtmltopdf-binary

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,6 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.36)
-    wkhtmltopdf-binary (0.9.9.1)
 
 PLATFORMS
   ruby
@@ -108,4 +107,3 @@ DEPENDENCIES
   rails (>= 3.0.0)
   shoulda
   sqlite3
-  wkhtmltopdf-binary

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ More information about [wkhtmltopdf](http://code.google.com/p/wkhtmltopdf/) coul
 Add this to your Gemfile:
 
     gem 'wisepdf'
+    
+if you don't already have wkhtmltopdf installed on your machine you can get up and running quickly by adding this to your Gemfile:
+
+    gem 'wkhtmltopdf-binary'
 
 then do:
     

--- a/wisepdf.gemspec
+++ b/wisepdf.gemspec
@@ -97,14 +97,12 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<sqlite3>, [">= 0"])
-      s.add_development_dependency(%q<wkhtmltopdf-binary>, [">= 0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<bundler>, [">= 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_development_dependency(%q<rails>, [">= 3.0.0"])
     else
       s.add_dependency(%q<sqlite3>, [">= 0"])
-      s.add_dependency(%q<wkhtmltopdf-binary>, [">= 0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<bundler>, [">= 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.6.4"])
@@ -112,7 +110,6 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<sqlite3>, [">= 0"])
-    s.add_dependency(%q<wkhtmltopdf-binary>, [">= 0"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<bundler>, [">= 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.6.4"])


### PR DESCRIPTION
I recommend removing the wkhtmltopdf-binary dependency because it creates unnecessary bloat since it contains binaries irrelevant to the current platform.

I updated the docs to include info about adding the wkhtmltopdf-binary gem so users can still get up and running quickly. I kept the wkhtmltopdf-binary gem in the Gemfile for testing purposes.

This change is important in my case because I'm using my own binary of wkhtmltopdf 0.11.0_rc1 since it contains some performance improvements, and it also fixes a bug that allows anchor links to work within pdfs. Using wisepdf with wkhtmltopdf 0.11.0_rc1 I haven't run into any issues and the tests still pass when specifying that binary.
