### PR TITLE
Fix rails engine and asset pipeline for Rails 4.0

### DIFF
--- a/lib/wisepdf/rails.rb
+++ b/lib/wisepdf/rails.rb
@@ -3,7 +3,7 @@ module Wisepdf
     if ::Rails::VERSION::MAJOR == 2
       require 'wisepdf/rails/legacy'
     elsif ::Rails::VERSION::MAJOR > 2
-      if ::Rails::VERSION::MINOR < 1
+      if ::Rails::VERSION::MAJOR == 3 && ::Rails::VERSION::MINOR < 1
         require 'wisepdf/rails/railtie'
       else
         require 'wisepdf/rails/engine'

--- a/lib/wisepdf/rails/engine.rb
+++ b/lib/wisepdf/rails/engine.rb
@@ -3,7 +3,7 @@ module Wisepdf
     class Engine < ::Rails::Engine
       initializer "wicked_pdf.register" do
         ActionController::Base.send :include, Render
-        if ::Rails.configuration.assets.enabled
+        if ::Rails.configuration.assets.enabled != false
           ActionView::Base.send :include, Helper::Assets
         else
           ActionView::Base.send :include, Helper::Legacy


### PR DESCRIPTION
The Rails version check was checking the minor version based on the major version only being larger than 2. Fix it to only use railtie if Rails is 3.0.

The Rails engine was not checking properly for the asset pipeline. By default the asset pipeline is enabled. It is only when Rails.configuration.assets.enabled is set to false that the asset pipeline is disabled.
