### PR TITLE
if assets.enabled is left blank, the default is now to use the asset pipeline

### DIFF
--- a/lib/wisepdf/configuration.rb
+++ b/lib/wisepdf/configuration.rb
@@ -21,6 +21,12 @@ module Wisepdf
         yield self
       end
 
+      def use_asset_pipeline?
+        return true if ::Rails.configuration.assets.enabled.nil?
+
+        !!(::Rails.configuration.assets.enabled)
+      end
+
       def reset!
         @options = {
           :encoding => "UTF-8",

--- a/lib/wisepdf/rails/engine.rb
+++ b/lib/wisepdf/rails/engine.rb
@@ -3,7 +3,7 @@ module Wisepdf
     class Engine < ::Rails::Engine
       initializer "wise_pdf.register" do
         ActionController::Base.send :include, Render
-        if !!(::Rails.configuration.assets.enabled)
+        if Wisepdf::Configuration.use_asset_pipeline?
           ActionView::Base.send :include, Helper::Assets
         else
           ActionView::Base.send :include, Helper::Legacy

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -51,4 +51,25 @@ class ConfigurationTest < Test::Unit::TestCase
       assert_equal 15, Wisepdf::Configuration.options[:margin][:bottom]
     end
   end
+
+  context "Asset pipeline configuration" do
+    setup do
+      Wisepdf::Configuration.reset!
+    end
+
+    should "use the asset pipeline if assets.enabled is nil" do
+      ::Rails.configuration.assets.enabled = nil
+      assert(Wisepdf::Configuration.use_asset_pipeline?)
+    end
+
+    should "use the asset pipeline if assets.enabled is true" do
+      ::Rails.configuration.assets.enabled = true
+      assert(Wisepdf::Configuration.use_asset_pipeline?)
+    end
+
+    should "not use the asset pipeline if assets.enabled is false" do
+      ::Rails.configuration.assets.enabled = false
+      assert(!Wisepdf::Configuration.use_asset_pipeline?)
+    end
+  end
 end


### PR DESCRIPTION
The default behavior in Rails now is to use the asset pipeline.  The existing conditional in the railtie is `!!(::Rails.configuration.assets.enabled)`.  This actually evaluates to false for nil -- which essentially overrides the default behavior to use the legacy helpers. 

nil / left blank for assets.enabled should use the asset pipeline.  The engine railtie conditional is only run for Rails 3.2 + so we should be able to safely assume asset pipeline is the default.
