### PR TITLE
Fixed config generator template path

### DIFF
--- a/lib/generators/wisepdf_generator.rb
+++ b/lib/generators/wisepdf_generator.rb
@@ -1,7 +1,7 @@
 if defined?(Rails) && Rails::VERSION::MAJOR > 2
   # Rails3 generator invoked with 'rails generate wisepdf'
   class WisepdfGenerator < Rails::Generators::Base
-    source_root(File.expand_path(File.dirname(__FILE__) + "/../../generators/pdf/templates"))
+    source_root(File.expand_path(File.dirname(__FILE__) + "/../../generators/wisepdf/templates"))
     def copy_initializer
       copy_file 'configure_wisepdf.rb', 'config/initializers/configure_wisepdf.rb'
     end

--- a/lib/wisepdf/version.rb
+++ b/lib/wisepdf/version.rb
@@ -4,7 +4,7 @@ module Wisepdf
   module Version
     MAJOR = 1
     MINOR = 4
-    PATCH = 0
+    PATCH = 1
     BUILD = nil
 
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')


### PR DESCRIPTION
Generator was configured with the wrong path and wouldn't work. This fixes it.
