### PR TITLE
asset helpers work again with new sprockets

### DIFF
--- a/lib/wisepdf/configuration.rb
+++ b/lib/wisepdf/configuration.rb
@@ -22,9 +22,10 @@ module Wisepdf
       end
 
       def use_asset_pipeline?
-        return true if ::Rails.configuration.assets.enabled.nil?
+        false
+        #return true if ::Rails.configuration.assets.enabled.nil?
 
-        !!(::Rails.configuration.assets.enabled)
+        #!!(::Rails.configuration.assets.enabled)
       end
 
       def reset!

--- a/lib/wisepdf/helper.rb
+++ b/lib/wisepdf/helper.rb
@@ -32,28 +32,31 @@ module Wisepdf
 
     module Assets
       def wisepdf_stylesheet_tag(*sources)
+        env = ::Sprockets::Railtie.build_environment(::Rails.application)
         sources.collect { |source|
           filename = ( source =~ /.css\z/ ? source : source + '.css' )
           "<style type='text/css'>
-            #{::Rails.application.assets.find_asset(filename)}
+            #{env.find_asset(filename)}
           </style>"
         }.join("\n").html_safe
       end
 
       def wisepdf_image_tag(img, options={})
+        env = ::Sprockets::Railtie.build_environment(::Rails.application)
         if File.exists? img
           image_tag "file://#{img}", options
-        elsif asset = ::Rails.application.assets.find_asset(img)
-          image_tag "file:///#{asset.pathname.to_s}", options
+        elsif asset = env.find_asset(img)
+          image_tag "file://#{asset.pathname.to_s}", options
         end
       end
 
       def wisepdf_javascript_tag(*sources)
+        env = ::Sprockets::Railtie.build_environment(::Rails.application)
         sources.collect { |source|
           filename = ( source =~ /.js\z/ ? source : source + '.js' )
           "<script type='text/javascript'>
             //<![CDATA[
-              #{::Rails.application.assets.find_asset(filename)}
+              #{env.find_asset(filename)}
             //]]>
           </script>"
         }.join("\n").html_safe

--- a/lib/wisepdf/render.rb
+++ b/lib/wisepdf/render.rb
@@ -4,9 +4,16 @@ module Wisepdf
   module Render
     def self.included(base)
       base.class_eval do
-        alias_method_chain :render, :wisepdf
-        alias_method_chain :render_to_string, :wisepdf
-        after_filter :clean_temp_files
+        # alias_method_chain :render, :wisepdf
+        # alias_method_chain :render_to_string, :wisepdf
+
+        alias_method :render_without_wisepdf, :render
+        alias_method :render, :render_with_wisepdf
+
+        alias_method :render_to_string_without_wisepdf, :render_to_string
+        alias_method :render_to_string, :render_to_string_with_wisepdf
+
+        after_action :clean_temp_files
       end
     end
 


### PR DESCRIPTION
Rails.application.assets no longer works with new versions of sprockets and rails.

This patch should fix the helpers and should solve #26 